### PR TITLE
spdy connection close issue for streamd processor

### DIFF
--- a/cmd/streamd/main.go
+++ b/cmd/streamd/main.go
@@ -55,7 +55,9 @@ func main() {
 		log.Printf("Listen error: %s", err)
 		os.Exit(1)
 	}
-
+	
+	var spdyConns = make([] *spdystream.Connection, 128)
+	
 	go func() {
 		for {
 			conn, err := listener.Accept()
@@ -64,16 +66,25 @@ func main() {
 			}
 			spdyConn, err := spdystream.NewConnection(conn, true)
 			if err != nil {
+				conn.Close()
 				log.Printf("New spdyConnection error, %s", err)
 			}
+			spdyConns = append(spdyConns, spdyConn)
 			go spdyConn.Serve(AgentStreamHandler)
 		}
 	}()
-
+	
+	fmt.Printf("starting clean up connections...")
+	
 	// waiting for exit signals
 	for sig := range sigChan {
 		log.Printf("captured %v, exiting..", sig)
-
+		
+		for _, spdyConn := range spdyConns {
+			if nil != spdyConn{
+				spdyConn.Close()
+			}
+		}
 		return
 	}
 }


### PR DESCRIPTION
When kill the streamd processor, the program will close the all spdy connection from the spdy connection pools.
