### PR TITLE
When close backend connections, need to close the spdy connection explicitly.

### DIFF
--- a/engine/native/native.go
+++ b/engine/native/native.go
@@ -39,6 +39,13 @@ func Serve(settings *config.Configuration, wgroup *sync.WaitGroup, done chan str
 		wgroup.Add(1)
 		go func() {
 			<-done
+			
+			log.Printf("starting clean up connection....")
+			//close the backends connection for spdy
+			for addr, _ := range sch.backends {
+				sch.RemoveBackend(addr)
+			}
+			
 			listener.Close()
 		}()
 

--- a/engine/native/scheduler.go
+++ b/engine/native/scheduler.go
@@ -265,6 +265,10 @@ func (s *Scheduler) RemoveBackend(addr string) {
 		if b.index != -1 {
 			heap.Remove(&s.pool, b.index)
 		}
+		for i := 0; i < int(b.tunnels); i++ {
+			oneTunnel := b.tunnel[i]
+			oneTunnel.Close()
+		}
 		delete(s.backends, b.address)
 	} else {
 		log.Printf("balancer: %s is not up, bug might exist!", addr)

--- a/engine/native/spdy.go
+++ b/engine/native/spdy.go
@@ -84,3 +84,8 @@ func CreateSpdySession(request *spdySession, ready chan<- *spdySession) {
 	}
 	ready <- request
 }
+
+func (ct *connTunnel) Close() (error) {
+	ct.conn.Close()
+	return nil
+}


### PR DESCRIPTION
When close backend connections, need to close the spdy connection explicitly.
