### PR TITLE
Modifing handler.go for solution to the excessive number issue of tun…

### DIFF
--- a/cmd/streamd/handler.go
+++ b/cmd/streamd/handler.go
@@ -19,7 +19,7 @@ type copyRet struct {
 
 func streamCopy(dst io.WriteCloser, src io.Reader) {
 	io.Copy(dst, src)
-	dst.Close()
+	defer dst.Close()
 }
 
 // Tunnel Handler


### PR DESCRIPTION
…nel connections

Please notice that: defer dst.Close(). 

"defer" is a delay function, it isn't executed at once when it is declared; it can be called when main function executes "return" operation. Specific order depends on FIFO. It is always used in Exception handling, release resources, clean up the data, and so on.

When DB is closed in server side, corresponding tunnel connections also need to be closed. If "dst.Close()" is run at once after calling "io.Copy(dst, src)", dst will be closed before finishing close tunnel connections operation. So unused tunnel connections will be saved. When the DB is opened again, it will generate new tunnel connections. The scenario will lead to excessive tunnel connections issue.
